### PR TITLE
Verkle EOF draft

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -97,8 +97,9 @@ In the conditions below, “chunk chunk_id is accessed” is understood to mean 
 
  * At each step of EVM execution, if and only if `PC < len(code)`, chunk `PC // CHUNK_SIZE` (where `PC` is the current program counter) of the callee is accessed. In particular, note the following corner cases:
      * The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata
-     * The destination of a `JUMPI` is not considered to be accessed if the jump conditional is `false`.
-     * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing the `JUMP` opcode (including chunk access cost if the `JUMP` is the first opcode in a not-yet-accessed chunk)
+     * The destination of a `RJUMP/RJUMPV` (or positively evaluated `RJUMPI`) is considered to be accessed.
+     * The destination of a `JUMPI/RJUMPI` is not considered to be accessed if the jump conditional is `false`.
+     * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk)
      * The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
      * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed
  * If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed.
@@ -203,13 +204,13 @@ Reduce gas cost:
 
  * `CREATE`/`CREATE2` to 1000
 
-|Constant |Value|
-|-|-|
-|`WITNESS_BRANCH_COST`|1900|
-|`WITNESS_CHUNK_COST`	|200|
-|`SUBTREE_EDIT_COST`	|3000|
-|`CHUNK_EDIT_COST`    |500|
-|`CHUNK_FILL_COST`    |6200|
+| Constant              | Value |
+| --------------------- | ----- |
+| `WITNESS_BRANCH_COST` | 1900  |
+| `WITNESS_CHUNK_COST`  | 200   |
+| `SUBTREE_EDIT_COST`   | 3000  |
+| `CHUNK_EDIT_COST`     | 500   |
+| `CHUNK_FILL_COST`     | 6200  |
 
 When executing a transaction, maintain four sets:
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -94,28 +94,30 @@ In the conditions below, _chunk `chunk_id` is accessed_ is understood to mean an
 At each step of EVM execution, the corresponding code chunk for the current accessed bytecode is considered accessed:
 
 * For legacy code, corresponds to `PC` (global program counter).
-* For EOFv1 containers, corresponds to the pointed bytecode by `PC` within `current_section_index`.
+* For EOFv1 containers, corresponds to the bytecode by referenced by `PC` within `current_section_index`.
 
-In particular, note the following corner cases:
+In particular, note the following cases:
 
-* The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
-* The destination of a `RJUMP`, `RJUMPV`, `JUMPF`, `CALLF` , `RETF`, or positively evaluated `RJUMPI` is considered to be accessed. Note that a `RETF` always return to a valid bytecode which might be in a new code chunk.
+* The destination of a `JUMP` or positively evaluated `JUMPI` is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
+* The destination of a `RJUMP`, `RJUMPV`, `JUMPF`, `CALLF` , `RETF`, or positively evaluated `RJUMPI` is considered to be accessed.
 * The destination of a `JUMPI/RJUMPI` is not considered to be accessed if the jump conditional is `false`.
-* The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk)
-* The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
-* If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed
+* The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk).
+* For legacy code, the destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`).
+* If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed.
 
 If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed.
 
-If a nonzero-read-size `CODECOPY`,`EXTCODECOPY`, `DATALOAD`, `DATALOADN` or `DATACOPY` read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed:
+If a nonzero-read-size `CODECOPY` or `EXTCODECOPY` targeting an account with legacy code read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed:
 
 * Example 1: for a `CODECOPY` with start position 100, read size 50, `code_size = 200`, `x = 100` and `y = 149`
 * Example 2: for a `CODECOPY` with start position 600, read size 0, no chunks are accessed
 * Example 3: for a `CODECOPY` with start position 1500, read size 2000, `code_size = 3100`, `x = 1500` and `y = 3099`
 
+ If `EXTCODECOPY` targets an EOFv1 container, no code chunks are accessed since the code has hardcoded value `EF00`:
+
 Note that `CODESIZE`, `EXTCODESIZE` and `EXTCODEHASH` do NOT access any chunks.
 
-When a contract is created, access chunks `0 ... (len(code)+30)//31`.
+When a contract is created, access all corresponding chunks `0 ... (cod_size+30)//31`, where `code_size` is `len(code)` in legacy contracts, or the container size in EOFv1 accounts.
 
 #### Access events for EOFv1 container
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -203,6 +203,9 @@ For a transaction, make these access events:
 (tx.target, 0, BASIC_DATA_LEAF_KEY)
 (tx.target, 0, CODEHASH_LEAF_KEY)
 ```
+These accesses are not charged gas costs (i.e: included in intrinsic gas).
+
+If `tx.target` is an EOFv1 account, access code chunks corresponding to bytecode from the entire `header` and `type_section[0]` of the container. These accesses are charged gas costs, and done immediately after the above accesses.
 
 #### Write events
 
@@ -215,6 +218,8 @@ If `value` is non-zero:
 ```
 (tx.target, 0, BASIC_DATA_LEAF_KEY)
 ```
+
+These accesses are not charged gas costs (i.e: included in intrinsic gas).
 
 ### Witness gas costs
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -41,7 +41,7 @@ Whenever the state is read, one or more of the access events of the form`(addres
 
 When:
 
- 1. a non-precompile address is the target of a `*CALL`, `SELFDESTRUCT`, `EXTCODESIZE`, or `EXTCODECOPY` opcode, 
+ 1. a non-precompile address is the target of a `*CALL`, `EXT*CALL`, `SELFDESTRUCT`, `EXTCODESIZE`, or `EXTCODECOPY` opcode, 
  2. a non-precompile address is the target address of a contract creation whose initcode starts execution,
  3. any address is the target of the `BALANCE` opcode
  4. a _deployed_ contract calls `CODECOPY`
@@ -89,31 +89,43 @@ Where `tree_key` and `sub_key` are computed as `tree_key, sub_key = get_storage_
 
 #### Access events for code
 
-In the conditions below, “chunk chunk_id is accessed” is understood to mean an access event of the form
+In the conditions below, _chunk `chunk_id` is accessed_ is understood to mean an access event of the form `(address, (chunk_id + 128) // 256, (chunk_id + 128) % 256)`.
 
-```
-(address, (chunk_id + 128) // 256, (chunk_id + 128) % 256)
-```
+At each step of EVM execution, the corresponding code chunk for the current accessed bytecode is considered accessed:
 
- * At each step of EVM execution, if and only if `PC < len(code)`, chunk `PC // CHUNK_SIZE` (where `PC` is the current program counter) of the callee is accessed. In particular, note the following corner cases:
-     * The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
-     * The destination of a `RJUMP`, `RJUMPV`, `CALLF` , `RETF` or positively evaluated `RJUMPI` is considered to be accessed.
-     * The destination of a `JUMPI/RJUMPI` is not considered to be accessed if the jump conditional is `false`.
-     * The destination of a `JUMPF` was already accessed in the function call, so it can't charge a new code chunk.
-     * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk)
-     * The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
-     * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed
- * If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed.
- * If a nonzero-read-size `CODECOPY`,`EXTCODECOPY`, `DATALOAD`, `DATALOADN` or `DATACOPY` read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed.
-     * Example 1: for a `CODECOPY` with start position 100, read size 50, `code_size = 200`, `x = 100` and `y = 149`
-     * Example 2: for a `CODECOPY` with start position 600, read size 0, no chunks are accessed
-     * Example 3: for a `CODECOPY` with start position 1500, read size 2000, `code_size = 3100`, `x = 1500` and `y = 3099`
- * `CODESIZE`, `EXTCODESIZE` and `EXTCODEHASH` do NOT access any chunks.
- * When a contract is created, access chunks `0 ... (len(code)+30)//31`
+* For legacy code, corresponds to `PC` (global program counter).
+* For EOFv1 containers, corresponds to the pointed bytecode by `PC` within `current_section_index`.
 
-#### Access events for EOF containers
+In particular, note the following corner cases:
 
-If a `*CALL` or `EXT*CALL` targets an account with the EOF v1 container format, the entire `header` section is considered to be accessed (i.e: from `magic` to `terminator` included).
+* The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
+* The destination of a `RJUMP`, `RJUMPV`, `JUMPF`, `CALLF` , `RETF`, or positively evaluated `RJUMPI` is considered to be accessed. Note that a `RETF` always return to a valid bytecode which might be in a new code chunk.
+* The destination of a `JUMPI/RJUMPI` is not considered to be accessed if the jump conditional is `false`.
+* The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk)
+* The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
+* If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed
+
+If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed.
+
+If a nonzero-read-size `CODECOPY`,`EXTCODECOPY`, `DATALOAD`, `DATALOADN` or `DATACOPY` read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed:
+
+* Example 1: for a `CODECOPY` with start position 100, read size 50, `code_size = 200`, `x = 100` and `y = 149`
+* Example 2: for a `CODECOPY` with start position 600, read size 0, no chunks are accessed
+* Example 3: for a `CODECOPY` with start position 1500, read size 2000, `code_size = 3100`, `x = 1500` and `y = 3099`
+
+Note that `CODESIZE`, `EXTCODESIZE` and `EXTCODEHASH` do NOT access any chunks.
+
+When a contract is created, access chunks `0 ... (len(code)+30)//31`.
+
+#### Access events for EOFv1 container
+
+If a `*CALL` or `EXT*CALL` targets an account with the EOFv1 container format, the entire `header` section is considered to be accessed (i.e: from `magic` to `terminator` included).
+
+If a `CALLF` or `JUMPF` is executed, the corresponding `types_section` for the target section is accessed.
+
+If `DATALOAD`, `DATALOADN` or `DATACOPY` is executed, the targeted bytes of the `data_section` of the current container are considered to be accessed.
+
+Note that if `DATASIZE` is executed, no new access event is generated since the entire `header` of the current container was already accessed.
 
 ### Write Events
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -100,7 +100,7 @@ In particular, note the following cases:
 
 * The destination of a `JUMP` or positively evaluated `JUMPI` is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
 * The destination of a `RJUMP`, `RJUMPV`, `JUMPF`, `CALLF` , `RETF`, or positively evaluated `RJUMPI` is considered to be accessed.
-* The destination of a `JUMPI/RJUMPI` is not considered to be accessed if the jump conditional is `false`.
+* The destination of a `JUMPI`, or `RJUMPI` is not considered to be accessed if the jump conditional is `false`.
 * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk).
 * For legacy code, the destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`).
 * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed.

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -121,14 +121,14 @@ When a contract is created, access all corresponding chunks `0 ... (cod_size+30)
 
 #### Access events for EOFv1 container
 
-If a `*CALL` or `EXT*CALL` instruction targets an account with the EOFv1 container format or a `EOFCREATE` instruction is executed, the code chunks of the following bytecodes are considered accessed:
+If a `*CALL`, `EXT*CALL` instruction targets an account with the EOFv1 container format or a `EOFCREATE` instruction is executed, the code chunks of the following bytecodes are considered accessed:
 
 * The entire `header` section of the current (`*CALL`/`EXT*CALL`) or targeted (`EOFCREATE`) (sub-)container.
 * The entire `type_section[0]` of the current or targeted (sub-)container.
 
 If a `CALLF` or `JUMPF` instruction is executed, the corresponding code chunks of the target's entire `types_section`  and the first byte of the `code_section` for the target section are considered accessed.
 
-If a `RETURNCONTRACT` instruction is executed, the corresponding code chunks of the target's entire `types_section`  and  `code_section` for the target section are considered accessed.
+If a `RETURNCONTRACT` instruction is executed, the corresponding code chunks of the target's entire `types_section` and `code_section` for the target section are considered accessed.
 
 If `DATALOAD`, `DATALOADN` or `DATACOPY` is executed, the corresponding code chunks of the entire `data_section` of the current container are considered accessed.
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -97,19 +97,19 @@ In the conditions below, “chunk chunk_id is accessed” is understood to mean 
 
  * At each step of EVM execution, if and only if `PC < len(code)`, chunk `PC // CHUNK_SIZE` (where `PC` is the current program counter) of the callee is accessed. In particular, note the following corner cases:
      * The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
-     * The destination of a `RJUMP/RJUMPV/CALLF/RETF` or positively evaluated `RJUMPI` is considered to be accessed.
+     * The destination of a `RJUMP`, `RJUMPV`, `CALLF` , `RETF` or positively evaluated `RJUMPI` is considered to be accessed.
      * The destination of a `JUMPI/RJUMPI` is not considered to be accessed if the jump conditional is `false`.
      * The destination of a `JUMPF` was already accessed in the function call, so it can't charge a new code chunk.
      * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk)
      * The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
      * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed
  * If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed.
- * If a nonzero-read-size `CODECOPY` or `EXTCODECOPY` read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed.
+ * If a nonzero-read-size `CODECOPY`,`EXTCODECOPY`, `DATALOAD`, `DATALOADN` or `DATACOPY` read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed.
      * Example 1: for a `CODECOPY` with start position 100, read size 50, `code_size = 200`, `x = 100` and `y = 149`
      * Example 2: for a `CODECOPY` with start position 600, read size 0, no chunks are accessed
      * Example 3: for a `CODECOPY` with start position 1500, read size 2000, `code_size = 3100`, `x = 1500` and `y = 3099`
  * `CODESIZE`, `EXTCODESIZE` and `EXTCODEHASH` do NOT access any chunks.
-    When a contract is created, access chunks `0 ... (len(code)+30)//31`
+ * When a contract is created, access chunks `0 ... (len(code)+30)//31`
 
 ### Write Events
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -119,11 +119,16 @@ When a contract is created, access chunks `0 ... (len(code)+30)//31`.
 
 #### Access events for EOFv1 container
 
-If a `*CALL` or `EXT*CALL` targets an account with the EOFv1 container format, the entire `header` section is considered to be accessed (i.e: from `magic` to `terminator` included).
+If a `*CALL` or `EXT*CALL` instruction targets an account with the EOFv1 container format or a `EOFCREATE` instruction is executed, the code chunks of the following bytecodes are considered accessed:
 
-If a `CALLF` or `JUMPF` is executed, the corresponding `types_section` for the target section is accessed.
+* The entire `header` section of the current (`*CALL`/`EXT*CALL`) or targeted (`EOFCREATE`) (sub-)container.
+* The entire `type_section[0]` of the current or targeted (sub-)container.
 
-If `DATALOAD`, `DATALOADN` or `DATACOPY` is executed, the targeted bytes of the `data_section` of the current container are considered to be accessed.
+If a `CALLF` or `JUMPF` instruction is executed, the corresponding code chunks of the target's entire `types_section`  and the first byte of the `code_section` for the target section are considered accessed.
+
+If a `RETURNCONTRACT` instruction is executed, the corresponding code chunks of the target's entire `types_section`  and  `code_section` for the target section are considered accessed.
+
+If `DATALOAD`, `DATALOADN` or `DATACOPY` is executed, the corresponding code chunks of the entire `data_section` of the current container are considered accessed.
 
 Note that if `DATASIZE` is executed, no new access event is generated since the entire `header` of the current container was already accessed.
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -96,9 +96,10 @@ In the conditions below, “chunk chunk_id is accessed” is understood to mean 
 ```
 
  * At each step of EVM execution, if and only if `PC < len(code)`, chunk `PC // CHUNK_SIZE` (where `PC` is the current program counter) of the callee is accessed. In particular, note the following corner cases:
-     * The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata
-     * The destination of a `RJUMP/RJUMPV` (or positively evaluated `RJUMPI`) is considered to be accessed.
+     * The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
+     * The destination of a `RJUMP/RJUMPV/CALLF/RETF` or positively evaluated `RJUMPI` is considered to be accessed.
      * The destination of a `JUMPI/RJUMPI` is not considered to be accessed if the jump conditional is `false`.
+     * The destination of a `JUMPF` was already accessed in the function call, so it can't charge a new code chunk.
      * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk)
      * The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
      * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -130,7 +130,7 @@ If a `CALLF` or `JUMPF` instruction is executed, the corresponding code chunks o
 
 If a `RETURNCONTRACT` instruction is executed, the corresponding code chunks of the target's entire `types_section` and `code_section` for the target section are considered accessed.
 
-If `DATALOAD`, `DATALOADN` or `DATACOPY` is executed, the corresponding code chunks of the entire `data_section` of the current container are considered accessed.
+If `DATALOAD`, `DATALOADN` or `DATACOPY` is executed, the corresponding code chunks of the `data_section` of the current container are considered accessed. If `DATALOAD` or `DATACOPY` access bytes outside the `data_section`, those are not accessed (i.e: are assumed to be zero by [EIP-7480](./eip-7480.md)).
 
 Note that if `DATASIZE` is executed, no new access event is generated since the entire `header` of the current container was already accessed.
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -99,13 +99,13 @@ At each step of EVM execution, the corresponding code chunk for the current acce
 In particular, note the following cases:
 
 * The destination of a `JUMP` or positively evaluated `JUMPI` is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata.
-* The destination of a `RJUMP`, `RJUMPV`, `JUMPF`, `CALLF` , `RETF`, or positively evaluated `RJUMPI` is considered to be accessed.
+* The destination of a `RJUMP`, `RJUMPV`, `RETF`, or positively evaluated `RJUMPI` is considered to be accessed.
 * The destination of a `JUMPI`, or `RJUMPI` is not considered to be accessed if the jump conditional is `false`.
 * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing it (including chunk access cost if the jump is the first opcode in a not-yet-accessed chunk).
 * For legacy code, the destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`).
 * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed.
 
-If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed.
+If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed, where `PC` is the global program counter for legacy code or `PC` within `current_section_index` for EOFv1 containers.
 
 If a nonzero-read-size `CODECOPY` or `EXTCODECOPY` targeting an account with legacy code read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed:
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -111,6 +111,10 @@ In the conditions below, “chunk chunk_id is accessed” is understood to mean 
  * `CODESIZE`, `EXTCODESIZE` and `EXTCODEHASH` do NOT access any chunks.
  * When a contract is created, access chunks `0 ... (len(code)+30)//31`
 
+#### Access events for EOF containers
+
+If a `*CALL` or `EXT*CALL` targets an account with the EOF v1 container format, the entire `header` section is considered to be accessed (i.e: from `magic` to `terminator` included).
+
 ### Write Events
 
 We define **write events** as follows. Note that when a write takes place, an access event also takes place (so the definition below should be a subset of the definition of access events). A write event is of the form `(address, sub_key, leaf_key)`, determining what data is being written to.

--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -167,11 +167,19 @@ An account's `version`, `balance`, `nonce` and `code_size` fields are packed wit
 | Name        | Offset | Size |
 | ----------- | ------ | ---- |
 | `version`   | 0      | 1    |
+| `flags`     | 1      | 1    |
 | `code_size` | 5      | 3    |
 | `nonce`     | 8      | 8    |
 | `balance`   | 16     | 16   |
 
-Bytes `1..4` are reserved for future use.
+Bytes `2..4` are reserved for future use.
+
+The `flags` field is a bitfield with the following bits:
+| Nth-LSB | Name     | Description                    |
+| ------- | -------- | ------------------------------ |
+| 0       | `IS_EOF` | The account is an EOF contract |
+
+Bits `1..7` are reserved for future use.
 
 The current layout and encoding allow for an extension of `code_size` to 4 bytes without changing the account version.
 

--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -167,19 +167,11 @@ An account's `version`, `balance`, `nonce` and `code_size` fields are packed wit
 | Name        | Offset | Size |
 | ----------- | ------ | ---- |
 | `version`   | 0      | 1    |
-| `flags`     | 1      | 1    |
 | `code_size` | 5      | 3    |
 | `nonce`     | 8      | 8    |
 | `balance`   | 16     | 16   |
 
-Bytes `2..4` are reserved for future use.
-
-The `flags` field is a bitfield with the following bits:
-| Nth-LSB | Name     | Description                    |
-| ------- | -------- | ------------------------------ |
-| 0       | `IS_EOF` | The account is an EOF contract |
-
-Bits `1..7` are reserved for future use.
+Bytes `1..4` are reserved for future use.
 
 The current layout and encoding allow for an extension of `code_size` to 4 bytes without changing the account version.
 

--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -183,7 +183,7 @@ Bits `1..7` are reserved for future use.
 
 The current layout and encoding allow for an extension of `code_size` to 4 bytes without changing the account version.
 
-When any account header field is set, the `version` field is also set to zero. The `codehash` and `code_size` fields are set upon contract or EoA creation.
+When any account header field is set, the `version` field is also set to zero. The `codehash` and `code_size` fields are set upon contract or EoA creation. Note that for EOFv1 accounts, the `code_size` and `code_hash` values are hardcoded to `2` and `0x9dbf3648db8210552e9c4f75c6a1c3057c0ca432043bd648be15fe7be05646f5` respectively.
 
 #### Code
 

--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -214,6 +214,8 @@ def state_convert(state: State, stride: int):
             # it will return it from the VKT and write it again (i.e: it's a noop).
             # Thus, this operation is correct under both scenarios. That is, it won't
             # write stale data.
+            # Note that if the account is a EOFv1 account, the basic_data code-size and
+            # code-hash will have a constant value as defined in the spec.
             account = get_account(state, curr_account.address)
             set_account(state, curr_account.address, account)
             n += 1


### PR DESCRIPTION
_[Note: this is a tentative PR to get feedback before creating the real PR]_
_[Note: I'm quite heavy in commenting just to explain rationale. I won't create so many PR comments in the eventual final PR]_

This PR changes EIP-6800, EIP-4762, and EIP-7748 to consider EOF.

I make minimal changes to fix the spec to avoid bloating the PR. We can reorganize/refactor the EIPs in the future -- I avoid doing that in this PR to reduce the review footprint.

I think it will be helpful for reviewers to have the following references to inspect new EOF instructions:
- https://eips.ethereum.org/EIPS/eip-3540: EOFv1 container
- https://eips.ethereum.org/EIPS/eip-4200: RJUMP, RJUMPI, RJUMPV
- https://eips.ethereum.org/EIPS/eip-4750: CALLF, RETF
- https://eips.ethereum.org/EIPS/eip-6206: JUMPF
- https://eips.ethereum.org/EIPS/eip-7480: DATALOAD, DATALOADN, DATASIZE, DATACOPY
- https://eips.ethereum.org/EIPS/eip-663: SWAPN, DUPN, EXCHANGE
- https://eips.ethereum.org/EIPS/eip-7620: EOFCREATE and RETURNCONTRACT
- https://eips.ethereum.org/EIPS/eip-7069: EXTCALL, EXTDELEGATECALL, EXTSTATICCALL, RETURNDATALOAD